### PR TITLE
Use latest Ships.sol ABI

### DIFF
--- a/check.js
+++ b/check.js
@@ -191,7 +191,7 @@ async function canSpawn(contracts, ship, target) {
   let ts         = Math.round(new Date().getTime() / 1000);
   let spawnLimit = await constitution.getSpawnLimit(contracts, prefix, ts);
   if (!ships.hasBeenBooted(contracts, parentShipObj) ||
-      parentShipObj.spawnCount >= spawnLimit)
+      (await ships.getSpawnCount(contracts, ship)) >= spawnLimit)
   {
     res.reason = reasons.spawnPrefix;
     return res;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "urbit-constitution-js",
-  "version": "0.5.0",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "urbit-constitution-js",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Functions for interacting with Azimuth",
   "repository": {
     "type": "git",

--- a/resources/abis.json
+++ b/resources/abis.json
@@ -988,6 +988,29 @@
       "inputs": [
         {
           "name": "",
+          "type": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "name": "escapeRequestsIndexes",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
           "type": "address"
         },
         {
@@ -1092,6 +1115,29 @@
       "inputs": [
         {
           "name": "",
+          "type": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "sponsoring",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
           "type": "address"
         },
         {
@@ -1104,6 +1150,29 @@
         {
           "name": "",
           "type": "bool"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "name": "sponsoringIndexes",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
         }
       ],
       "payable": false,
@@ -1231,6 +1300,29 @@
         {
           "name": "",
           "type": "uint32"
+        },
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "escapeRequests",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint32"
         }
       ],
       "name": "ships",
@@ -1257,10 +1349,6 @@
         },
         {
           "name": "continuityNumber",
-          "type": "uint32"
-        },
-        {
-          "name": "spawnCount",
           "type": "uint32"
         },
         {
@@ -2485,6 +2573,82 @@
       "outputs": [],
       "payable": false,
       "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_sponsor",
+          "type": "uint32"
+        }
+      ],
+      "name": "getSponsoringCount",
+      "outputs": [
+        {
+          "name": "count",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_sponsor",
+          "type": "uint32"
+        }
+      ],
+      "name": "getSponsoring",
+      "outputs": [
+        {
+          "name": "sponsees",
+          "type": "uint32[]"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_sponsor",
+          "type": "uint32"
+        }
+      ],
+      "name": "getEscapeRequestsCount",
+      "outputs": [
+        {
+          "name": "count",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_sponsor",
+          "type": "uint32"
+        }
+      ],
+      "name": "getEscapeRequests",
+      "outputs": [
+        {
+          "name": "requests",
+          "type": "uint32[]"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
       "type": "function"
     },
     {

--- a/ships.js
+++ b/ships.js
@@ -134,13 +134,10 @@ function getContinuityNumber(contracts, ship) {
 /**
  * Get a ship's spawn count.
  * @param {Object} contracts - An Urbit contracts object.
- * @param {Number | Object} ship - Ship token or ship object.
+ * @param {Number} ship - Ship token.
  * @return {Promise<Number>} The ship's spawn count.
  */
 function getSpawnCount(contracts, ship) {
-  if (typeof ship === 'object') {
-    return ship.spawnCount;
-  }
   return internal.getSpawnCount(contracts, ship);
 }
 


### PR DESCRIPTION
Latest version of Ships.sol no longer has `spawnCount` in the `Hull`. The ABI we uses needs to reflect that.

(It's probably possible to use whatever ABIs we get/build from the Azimuth dependency? We should probably do that, it might make reasons for breakage more obvious.)

The updated ABI also exposes a reverse lookup for sponsorship, but that doesn't get exposed through constitution-js yet.

Fixes #9, but a `#polls` test still fails, likely because it's hitting [this](https://github.com/urbit/azimuth/blob/master/contracts/Polls.sol#L355) for the same issue the test below it has the `FIXME`.