### PR TITLE
Fix problematic artifact of renaming.

### DIFF
--- a/azimuth.js
+++ b/azimuth.js
@@ -355,7 +355,7 @@ async function getPoint(contracts, point, what) {
  * @param {String} address - The target address.
  * @return {Promise<Array<Number>>} An array of owned azimuth.
  */
-const getOwnedPointsByAddress = internal.getOwnedPointsByAddress;
+const getOwnedPoints = internal.getOwnedPoints;
 
 /**
  * Get a count of points owned by an address.
@@ -488,7 +488,7 @@ const isOperator = internal.isOperator;
 module.exports = {
   owner,
   getPoint,
-  getOwnedPointsByAddress,
+  getOwnedPoints,
   getOwnedPointCount,
   getOwnedPointAtIndex,
   isManagementProxy,

--- a/internal/azimuth.js
+++ b/internal/azimuth.js
@@ -11,8 +11,8 @@ module.exports.getRights = (contracts, point) => {
   return contracts.azimuth.methods.rights(point).call();
 }
 
-module.exports.getOwnedPointsByAddress = (contracts, address) => {
-  return contracts.azimuth.methods.getOwnedPointsByAddress(address).call();
+module.exports.getOwnedPoints = (contracts, address) => {
+  return contracts.azimuth.methods.getOwnedPoints(address).call();
 }
 
 module.exports.getOwnedPointCount = (contracts, address) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azimuth-js",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azimuth-js",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Functions for interacting with Azimuth",
   "repository": {
     "type": "git",


### PR DESCRIPTION
'getOwnedPointsByAddress' in the Azimuth contract had been renamed to 'getOwnedPoints', but we hadn't renamed it here.

(I haven't checked to see if there are other similar artifacts like this -- this one just happened to trigger an error downstream.)