### PR TITLE
Expose initContractsPartial

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const txn = require('./txn');
 const utils = require('./utils');
 
 const initContracts = contracts.initContracts;
+const initContractsPartial = contracts.initContractsPartial;
 
 const getKeyPair = accounts.getKeyPair;
 
@@ -30,5 +31,6 @@ module.exports = {
   txn,
   utils,
   initContracts,
+  initContractsPartial,
   getKeyPair
 }


### PR DESCRIPTION
Not sure why this wasn't being exposed. Just passing in the Azimuth address should be *the* way to make sure you don't have to touch your codebase whenever the Ecliptic upgrades.