### PR TITLE
Add support for DelegatedSending

### DIFF
--- a/check.js
+++ b/check.js
@@ -7,6 +7,7 @@ const { eclipticAbi } = require('./contracts');
 const ecliptic = require('./ecliptic');
 const azimuth = require('./azimuth');
 const polls = require('./polls');
+const delegatedSending = require('./delegatedSending');
 const utils = require('./utils');
 const reasons = require('./resources/reasons.json');
 
@@ -714,6 +715,51 @@ async function csrCanForfeit(contracts, batch, address) {
   return res;
 }
 
+/**
+ * Check if the address can give invites to point
+ * @param {Number} point - Point number to give invites to
+ * @param {String} address - The caller address
+ * @return {Promise<Object>} A result and reason pair
+ */
+async function canSetPoolSize(contracts, point, address) {
+  return checkActivePointOwner(contracts, azimuth.getPrefix(point), address);
+}
+
+/**
+ * Check if as can send point as an invite to to
+ * @param {Number} as - The point that would send the invite
+ * @param {Number} point - The point that would be sent as invite
+ * @param {String} to - The Ethereum address recipient of the invite
+ * @param {String} address - The caller address
+ * @return {Promise<Object>} A result and reason pair
+ */
+async function canSendInvitePoint(contracts, as, point, to, address) {
+  let res = await checkActivePointOwner(contracts, as, address);
+  if (!res.result) {
+    console.log('first');
+    return res;
+  }
+  res.result = false;
+  if (to === address) {
+    res.reason = reasons.cantReceive;
+    return res;
+  }
+  let canSend = await delegatedSending.canSend(contracts, as, point);
+  if (!canSend) {
+    res.reason = reasons.permission;
+    console.log('third');
+    return res;
+  }
+  let canReceive = await delegatedSending.canReceive(contracts, to);
+  if (!canReceive) {
+    res.reason = reasons.cantReceive;
+    return res;
+  }
+  res.result = true;
+  return res;
+}
+
+
 module.exports = {
   ecliptic,
   azimuth,
@@ -751,5 +797,7 @@ module.exports = {
   lsrCanTransferBatch,
   csrCanWithdraw,
   csrCanTransferBatch,
-  csrCanForfeit
+  csrCanForfeit,
+  canSetPoolSize,
+  canSendInvitePoint,
 }

--- a/check.js
+++ b/check.js
@@ -736,7 +736,6 @@ async function canSetPoolSize(contracts, point, address) {
 async function canSendInvitePoint(contracts, as, point, to, address) {
   let res = await checkActivePointOwner(contracts, as, address);
   if (!res.result) {
-    console.log('first');
     return res;
   }
   res.result = false;
@@ -747,7 +746,6 @@ async function canSendInvitePoint(contracts, as, point, to, address) {
   let canSend = await delegatedSending.canSend(contracts, as, point);
   if (!canSend) {
     res.reason = reasons.permission;
-    console.log('third');
     return res;
   }
   let canReceive = await delegatedSending.canReceive(contracts, to);

--- a/check.js
+++ b/check.js
@@ -739,7 +739,7 @@ async function canSendInvitePoint(contracts, as, point, to, address) {
     return res;
   }
   res.result = false;
-  if (to === address) {
+  if (utils.addressEquals(to, address)) {
     res.reason = reasons.cantReceive;
     return res;
   }

--- a/contracts.js
+++ b/contracts.js
@@ -15,6 +15,9 @@ const pollsAbi =
 const linearStarReleaseAbi =
   require('azimuth-solidity/build/contracts/LinearStarRelease.json').abi;
 
+const delegatedSendingAbi =
+  require('azimuth-solidity/build/contracts/DelegatedSending.json').abi;
+
 /**
  * Create a collection of Urbit contracts, given a web3 instance and their
  * provided addresses.
@@ -28,6 +31,7 @@ const initContracts = (web3, addresses) => ({
   azimuth: newAzimuth(web3, addresses.azimuth),
   polls: newPolls(web3, addresses.polls),
   linearSR: newLinearStarRelease(web3, addresses.linearSR),
+  delegatedSending: newDelegatedSending(web3, addresses.delegatedSending)
 });
 
 /**
@@ -62,11 +66,15 @@ const newPolls = (web3, address) =>
 const newLinearStarRelease = (web3, address) =>
   new web3.eth.Contract(linearStarReleaseAbi, address);
 
+const newDelegatedSending = (web3, address) =>
+  new web3.eth.Contract(delegatedSendingAbi, address);
+
 module.exports = {
   initContracts,
   initContractsPartial,
   eclipticAbi,
   azimuthAbi,
   pollsAbi,
-  linearStarReleaseAbi
+  linearStarReleaseAbi,
+  delegatedSendingAbi
 }

--- a/delegatedSending.js
+++ b/delegatedSending.js
@@ -1,0 +1,72 @@
+/**
+ * Delegated Sending
+ * @module delegatedSending
+ */
+
+const internal = require('./internal/delegatedSending');
+
+//TODO write docstrings
+
+/**
+ * Return the amount of invites left in the pool
+ * @param {Number} pool - Pool number
+ * @return {Promise<Number>} Number of invites remaining
+ */
+module.exports.pools = internal.pools
+module.exports.invitesInPool = internal.pools
+
+/**
+ * Return the points invited by point
+ * @param {Number} point - Point number
+ * @return {Promise<Array<Number>>} Points invited by point
+ */
+module.exports.getInvited = internal.getInvited
+
+/**
+ * Return the point that point was invited by
+ * @param {Number} point - Point number
+ * @return {Promise<Number>} The inviter point (0 if not invited)
+ */
+module.exports.invitedBy = internal.invitedBy
+
+/**
+ * Returns true if as can send point, false otherwise
+ * @param {Number} as - The inviter
+ * @param {Number} point - The point to send
+ * @return {Promise<Bool>} Whether as can send point
+ */
+module.exports.canSend = internal.canSend
+
+/**
+ * Get the invite pool point belongs to
+ * @param {Number} point - Point number
+ * @return {Promise<Number>} Pool number
+ */
+module.exports.getPool = internal.getPool
+module.exports.invitingFromPool = internal.getPool
+
+/**
+ * Returns true if receipients is eligible to receive a point, false otherwise
+ * @param {String} recipient - Ethereum address
+ * @return {Promise<Bool>} Whether recipient can receive a point
+ */
+module.exports.canReceive = internal.canReceive
+
+
+/**
+ * Give for (and their invite tree) access to size invites
+ * @param {Number} for - point to give invites to
+ * @param {Number} size - amount of invites to give
+ * @return {Object} An unsigned transaction object
+ */
+module.exports.setPoolSize = internal.setPoolSize
+
+/**
+ * As as, send the point to to
+ * @param {Number} as - point to send the invite as
+ * @param {Number} point - the point to send as an invite
+ * @param {String} to - target Ethereum address
+ * @return {Object} An unsigned transaction object
+ */
+module.exports.sendPoint = internal.sendPoint
+

--- a/delegatedSending.js
+++ b/delegatedSending.js
@@ -5,8 +5,6 @@
 
 const internal = require('./internal/delegatedSending');
 
-//TODO write docstrings
-
 /**
  * Return the amount of invites left in the pool
  * @param {Number} pool - Pool number

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const contracts = require('./contracts');
 const linearSR = require('./linearSR');
 const polls = require('./polls');
 const azimuth = require('./azimuth');
+const delegatedSending = require('./delegatedSending');
 const txn = require('./txn');
 const utils = require('./utils');
 
@@ -28,6 +29,7 @@ module.exports = {
   linearSR,
   polls,
   azimuth,
+  delegatedSending,
   txn,
   utils,
   initContracts,

--- a/internal/delegatedSending.js
+++ b/internal/delegatedSending.js
@@ -1,0 +1,61 @@
+
+//TODO ordering
+
+module.exports.pools = (contracts, point) => {
+  return contracts.delegatedSending.methods.pools(point).call();
+}
+
+module.exports.getInvited = (contracts, point) => {
+  return contracts.delegatedSending.methods.getInvited(point).call();
+}
+
+module.exports.invitedBy = (contracts, point) => {
+  return contracts.delegatedSending.methods.invitedBy(point).call();
+}
+
+module.exports.canSend = (contracts, as, point) => {
+  return contracts.delegatedSending.methods.canSend(as, point).call();
+}
+
+module.exports.getPool = (contracts, point) => {
+  return contracts.delegatedSending.methods.getPool(point).call();
+}
+
+module.exports.canReceive = (contracts, recipient) => {
+  return contracts.delegatedSending.methods.canReceive(recipient).call();
+}
+
+// NB (jtobin):
+//
+//   The following is extremely repetitive.  Could obviously abstract via
+//   function pointers/variadic arguments, e.g. something like:
+//
+//     function txFromMethod(method, ...args) {
+//       let addr = contracts.delegatedSending.address;
+//       let data = contracts.delegatedSending.methods.method.apply(this, args);
+//       let abi  = data.encodeABI();
+//       return tx(addr, abi, 0);
+//     }
+//
+//   Except handling 'method' appropriately.  But, given there are only a
+//   handful of functions, it's probably not worth doing any metaprogramming.
+
+const tx = (to, data, value) => ({
+  to: to,
+  data: data,
+  value: value || 0x0
+});
+
+module.exports.setPoolSize = (contracts, _for, _size) => {
+  let addr = contracts.delegatedSending._address;
+  let data = contracts.delegatedSending.methods.setPoolSize(_for, _size);
+  let abi  = data.encodeABI();
+  return tx(addr, abi, 0);
+}
+
+module.exports.sendPoint = (contracts, _as, _point, _to) => {
+  let addr = contracts.delegatedSending._address;
+  let data = contracts.delegatedSending.methods.sendPoint(_as, _point, _to);
+  let abi  = data.encodeABI();
+  return tx(addr, abi, 0);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azimuth-js",
-  "version": "0.8.3",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -301,9 +301,9 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "azimuth-solidity": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/azimuth-solidity/-/azimuth-solidity-1.0.2.tgz",
-      "integrity": "sha512-Yj+iAz/o7ladrRmjlWnnn7zqq5aVTQ1iKKprUBcbhxWnTfSfKvHwcF99Nyx6jNN7UjdiQ+gWt+4lJTlg1iewPg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/azimuth-solidity/-/azimuth-solidity-1.1.0.tgz",
+      "integrity": "sha512-YhVWKql1ZZ9Zae96nYA7QLwQlTzGspkNOErq170sl/UJwncQbvAyibSv+heMaS18n4soPDiRSpa1vHFoGoIX1A==",
       "requires": {
         "babel-polyfill": "^6.26.0",
         "babel-register": "^6.26.0",
@@ -727,7 +727,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -839,9 +839,9 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-js": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.1.tgz",
-      "integrity": "sha512-L72mmmEayPJBejKIWe2pYtGis5r0tQ5NaJekdhyXgeMQTpJoBsH0NL4ElY2LfSoV15xeQWKQ+XTTOZdyero5Xg=="
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2299,7 +2299,7 @@
     },
     "jsesc": {
       "version": "1.3.0",
-      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
     },
     "json-parse-better-errors": {
@@ -2325,7 +2325,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
@@ -3989,7 +3989,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
@@ -4002,7 +4002,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-cancelable": {
@@ -4924,14 +4924,6 @@
         "mime-types": "~2.1.18"
       }
     },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
@@ -5286,8 +5278,19 @@
       "integrity": "sha1-j93qQuGbvyUh7IeVRkV6Yjqdye8=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "web3-core-helpers": "1.0.0-beta.33"
+      },
+      "dependencies": {
+        "websocket": {
+          "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "requires": {
+            "debug": "^2.2.0",
+            "nan": "^2.3.3",
+            "typedarray-to-buffer": "^3.1.2",
+            "yaeti": "^0.0.6"
+          }
+        }
       }
     },
     "web3-shh": {
@@ -5320,16 +5323,6 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         }
-      }
-    },
-    "websocket": {
-      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
-      "requires": {
-        "debug": "^2.2.0",
-        "nan": "^2.3.3",
-        "typedarray-to-buffer": "^3.1.2",
-        "yaeti": "^0.0.6"
       }
     },
     "which": {
@@ -5422,11 +5415,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-    },
-    "yaeti": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yargs": {
       "version": "4.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -236,7 +236,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-map": {
@@ -515,7 +515,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
         "readable-stream": "^2.3.5",
@@ -612,7 +612,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "^4.1.0",
@@ -727,7 +727,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -812,7 +812,7 @@
     },
     "content-disposition": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
@@ -1023,12 +1023,12 @@
       "dependencies": {
         "file-type": {
           "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
         },
         "get-stream": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "requires": {
             "object-assign": "^4.0.1",
@@ -1094,7 +1094,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -1361,7 +1361,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
@@ -1875,7 +1875,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "getpass": {
@@ -2064,7 +2064,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -2299,7 +2299,7 @@
     },
     "jsesc": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
     },
     "json-parse-better-errors": {
@@ -2325,7 +2325,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
@@ -2451,7 +2451,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "memorystream": {
@@ -2840,6 +2840,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -3164,7 +3165,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -3248,6 +3250,7 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3294,7 +3297,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -3560,7 +3564,8 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",
@@ -3989,7 +3994,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
@@ -4002,7 +4007,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-cancelable": {
@@ -4025,7 +4030,7 @@
     },
     "parse-asn1": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "requires": {
         "asn1.js": "^4.0.0",
@@ -4202,7 +4207,7 @@
     },
     "query-string": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "requires": {
         "decode-uri-component": "^0.2.0",
@@ -4269,7 +4274,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -4381,7 +4386,7 @@
     },
     "scrypt.js": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
       "integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
       "requires": {
         "scrypt": "^6.0.2",
@@ -4421,7 +4426,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "requires": {
             "graceful-readlink": ">= 1.0.0"
@@ -4518,7 +4523,7 @@
       "dependencies": {
         "nan": {
           "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
           "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
         }
       }
@@ -4672,7 +4677,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -4748,7 +4753,7 @@
     },
     "tar": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "requires": {
         "block-stream": "*",
@@ -4784,7 +4789,7 @@
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         }
       }
@@ -4807,7 +4812,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "timed-out": {
@@ -4924,6 +4929,14 @@
         "mime-types": "~2.1.18"
       }
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
@@ -4945,7 +4958,7 @@
         },
         "buffer": {
           "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
           "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
           "requires": {
             "base64-js": "0.0.8",
@@ -4957,7 +4970,7 @@
     },
     "underscore": {
       "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "unorm": {
@@ -4999,7 +5012,7 @@
     },
     "utf8": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
       "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
     },
     "util-deprecate": {
@@ -5195,7 +5208,7 @@
         },
         "uuid": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         }
       }
@@ -5278,19 +5291,8 @@
       "integrity": "sha1-j93qQuGbvyUh7IeVRkV6Yjqdye8=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "websocket": {
-          "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "requires": {
-            "debug": "^2.2.0",
-            "nan": "^2.3.3",
-            "typedarray-to-buffer": "^3.1.2",
-            "yaeti": "^0.0.6"
-          }
-        }
+        "web3-core-helpers": "1.0.0-beta.33",
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
       }
     },
     "web3-shh": {
@@ -5323,6 +5325,16 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         }
+      }
+    },
+    "websocket": {
+      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+      "requires": {
+        "debug": "^2.2.0",
+        "nan": "^2.3.3",
+        "typedarray-to-buffer": "^3.1.2",
+        "yaeti": "^0.0.6"
       }
     },
     "which": {
@@ -5415,6 +5427,11 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yargs": {
       "version": "4.8.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "truffle": "4.1.11"
   },
   "dependencies": {
-    "azimuth-solidity": "1.0.2",
+    "azimuth-solidity": "1.1.0",
     "ethereumjs-util": "^5.2.0",
     "web3": "1.0.0-beta.33"
   },

--- a/resources/reasons.json
+++ b/resources/reasons.json
@@ -22,5 +22,6 @@
   "hasForfeited": "Commitment has already forfeited",
   "notMissed":    "Deadline has not been missed",
   "notApproved":  "Not approved for transfer",
+  "cantReceive":  "Target not eligible to receive",
   "empty":        ""
 }

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,7 @@ const cjs = require('..');
 const check = cjs.check;
 const ecliptic = cjs.ecliptic;
 const azimuth = cjs.azimuth;
+const delsend = cjs.delegatedSending;
 const txn = cjs.txn;
 
 const reasons = require('../resources/reasons.json');
@@ -43,7 +44,8 @@ const zaddr = ethUtil.zeroAddress();
 const contractAddresses = {
     ecliptic: '0x56db68f29203ff44a803faa2404a44ecbb7a7480',
     azimuth:  '0x863d9c2e5c4c133596cfac29d55255f0d0f86381',
-    polls:    '0x935452c45eda2958976a429c9733c40302995efd'
+    polls:    '0x935452c45eda2958976a429c9733c40302995efd',
+    delegatedSending: '0xb71c0b6cee1bcae56dfe95cd9d3e41ddd7eafc43'
   }
 
 // helpers
@@ -490,7 +492,55 @@ function main() {
     //   cant(await check.canCastDocumentVote(contracts, galaxy, fakeHash, ac0),
     //     reasons.pollVoted);
     // });
-  })
+  });
+
+  describe('#delegatedSending', async function() {
+    let planet1c = 196864;
+    let planet1d = 262400;
+    it('sets up for tests', async function() {
+      let prep = ecliptic.spawn(contracts, planet1c, ac0);
+      await sendTransaction(web3, prep, pk0);
+      prep = ecliptic.setSpawnProxy(contracts, star1, contracts.delegatedSending._address);
+      await sendTransaction(web3, prep, pk0);
+      // ac0 now owns planet1c (in addition to star1)
+    });
+
+    it('checks for star ownership', async function() {
+      cant(await check.canSetPoolSize(contracts, planet1c, ac1),
+        reasons.permission);
+      can(await check.canSetPoolSize(contracts, planet1c, ac0));
+    });
+
+    it('generates usable transaction', async function() {
+      assert.equal(await delsend.pools(contracts, planet1c), 0);
+
+      let tx = delsend.setPoolSize(contracts, planet1c, 9);
+      await sendTransaction(web3, tx, pk0);
+
+      assert.equal(await delsend.pools(contracts, planet1c), 9);
+    });
+
+    it('checks invite send ability', async function() {
+      cant(await check.canSendInvitePoint(contracts, planet1c, planet1d, ac0, ac0),
+        reasons.cantReceive);
+      cant(await check.canSendInvitePoint(contracts, planet1c, planet1d, ac1, ac0),
+        reasons.cantReceive);
+      can(await check.canSendInvitePoint(contracts, planet1c, planet1d, ac2, ac0));
+    });
+
+    it('generates usable transaction', async function() {
+      let tx = delsend.sendPoint(contracts, planet1c, planet1d, ac2);
+      await sendTransaction(web3, tx, pk0);
+
+      assert.isTrue(await azimuth.isTransferProxy(contracts, planet1d, ac2));
+      assert.equal(await delsend.pools(contracts, planet1c), 8);
+      assert.equal(await delsend.invitedBy(contracts, planet1d), planet1c);
+      assert.equal(await delsend.getPool(contracts, planet1d), planet1c);
+      let invited = await delsend.getInvited(contracts, planet1c);
+      assert.equal(invited.length, 1);
+      assert.equal(invited[0], planet1d);
+    })
+  });
 }
 
 main();

--- a/test/test.js
+++ b/test/test.js
@@ -6,12 +6,12 @@ const hdkey  = require('hdkey');
 const Web3   = require('web3');
 const ethUtil  = require('ethereumjs-util');
 
-const cjs = require('..');
-const check = cjs.check;
-const ecliptic = cjs.ecliptic;
-const azimuth = cjs.azimuth;
-const delsend = cjs.delegatedSending;
-const txn = cjs.txn;
+const ajs = require('..');
+const check = ajs.check;
+const ecliptic = ajs.ecliptic;
+const azimuth = ajs.azimuth;
+const delsend = ajs.delegatedSending;
+const txn = ajs.txn;
 
 const reasons = require('../resources/reasons.json');
 
@@ -25,9 +25,9 @@ const hd = hdkey.fromMasterSeed(seed);
 
 const path = "m/44'/60'/0'/0";
 
-const pair0 = cjs.getKeyPair(hd, path, 0);
-const pair1 = cjs.getKeyPair(hd, path, 1);
-const pair2 = cjs.getKeyPair(hd, path, 2);
+const pair0 = ajs.getKeyPair(hd, path, 0);
+const pair1 = ajs.getKeyPair(hd, path, 1);
+const pair2 = ajs.getKeyPair(hd, path, 2);
 
 const ac0 = ethUtil.addHexPrefix(pair0.address.toString('hex'));
 const ac1 = ethUtil.addHexPrefix(pair1.address.toString('hex'));
@@ -95,7 +95,7 @@ function main() {
 
   let provider  = new Web3.providers.HttpProvider('http://localhost:8545');
   let web3      = new Web3(provider);
-  let contracts = cjs.initContracts(web3, contractAddresses);
+  let contracts = ajs.initContracts(web3, contractAddresses);
 
   let galaxy       = 0;
   let galaxyPlanet = 65536;


### PR DESCRIPTION
Depends on urbit/azimuth#12, for which the `package.json` will need to be updated still.

Also, I saw [this](https://github.com/urbit/azimuth-js/blob/delegated-sending/contracts.js#L75-L79), and kind of just want to expose the `newEcliptic` etc functions, instead of the bare ABIs. Any objections, @jtobin?