### PR TITLE
Implement function for getting not-yet-spawned child points

### DIFF
--- a/azimuth.js
+++ b/azimuth.js
@@ -378,10 +378,9 @@ async function getUnspawnedChildren(contracts, point) {
   }
   let spawned = await getSpawned(contracts, point);
   let unspawned = [];
-  let childCount = (size === PointSize.Galaxy) ? 255 : 65535;
-  let stepSize = childCount + 1;
-  for (i = 1; i <= childCount; i++) {
-    let child = point + (i*stepSize);
+  let childSpace = (size === PointSize.Galaxy) ? 0x100 : 0x1000;
+  for (i = 1; i < childSpace; i++) {
+    let child = point + (i*childSpace);
     if (spawned.indexOf(child.toString()) < 0) {
       unspawned.push(child);
     }

--- a/azimuth.js
+++ b/azimuth.js
@@ -382,7 +382,7 @@ async function getUnspawnedChildren(contracts, point) {
   let stepSize = childCount + 1;
   for (i = 1; i <= childCount; i++) {
     let child = point + (i*stepSize);
-    if (spawned.indexOf(''+child) < 0) {
+    if (spawned.indexOf(child.toString()) < 0) {
       unspawned.push(child);
     }
   }

--- a/azimuth.js
+++ b/azimuth.js
@@ -366,6 +366,30 @@ async function getPoint(contracts, point, what) {
 }
 
 /**
+ * Get a list of unspawned/spawnable points
+ * @param {Object} contracts - An Urbit contracts object.
+ * @param {Number} point - Point number.
+ * @return {Promise<Array<Number>>} - Unspawned children of point
+ */
+async function getUnspawnedChildren(contracts, point) {
+  let size = getPointSize(point);
+  if (size >= PointSize.Planet) {
+    return [];
+  }
+  let spawned = await getSpawned(contracts, point);
+  let unspawned = [];
+  let childCount = (size === PointSize.Galaxy) ? 255 : 65535;
+  let stepSize = childCount + 1;
+  for (i = 1; i <= childCount; i++) {
+    let child = point + (i*stepSize);
+    if (spawned.indexOf(''+child) < 0) {
+      unspawned.push(child);
+    }
+  }
+  return unspawned;
+}
+
+/**
  * Get the points that an address owns.
  * @param {Object} contracts - An Urbit contracts object.
  * @param {String} address - The target address.
@@ -525,6 +549,7 @@ module.exports = {
   getContinuityNumber,
   getSpawnCount,
   getSpawned,
+  getUnspawnedChildren,
   getSponsor,
   getSponsoring,
   getSponsoringCount,

--- a/test/test.js
+++ b/test/test.js
@@ -208,6 +208,7 @@ function main() {
 
       assert.isFalse(await azimuth.isOwner(contracts, star1, ac0));
       assert.isFalse(await azimuth.isActive(contracts, star1));
+      assert.equal((await azimuth.getUnspawnedChildren(contracts, galaxy)).length, 255);
 
       let tx = ecliptic.spawn(contracts, star1, ac0);
       await sendTransaction(web3, tx, pk0);
@@ -227,6 +228,7 @@ function main() {
       assert.isTrue(await azimuth.isOwner(contracts, star2, ac0));
       assert.isFalse(await azimuth.isActive(contracts, star2));
       assert.isTrue(await azimuth.isTransferProxy(contracts, star2, ac1));
+      assert.equal((await azimuth.getUnspawnedChildren(contracts, galaxy)).length, 253);
     });
 
     it('prevents spawning spawned points', async function() {


### PR DESCRIPTION
This should make it easier for UIs to present the user with options when spawning or performing similar operations.