### PR TITLE
Fix issue with contract object initialization

### DIFF
--- a/contracts.js
+++ b/contracts.js
@@ -59,6 +59,7 @@ const newContract = (web3, address, abi) => {
   //NOTE this allows us to support a broader range of web3 versions.
   //     see also #23.
   contract._address = (contract._address || contract.address);
+  contract.address = contract._address;
   return contract;
 }
 
@@ -75,7 +76,7 @@ const newLinearStarRelease = (web3, address) =>
   newContract(web3, address, linearStarReleaseAbi);
 
 const newDelegatedSending = (web3, address) =>
-  new web3.eth.Contract(delegatedSendingAbi, address);
+  newContract(web3, address, delegatedSendingAbi);
 
 module.exports = {
   initContracts,


### PR DESCRIPTION
The one for DelegatedSending was missed/not yet there in #23.

This also ensures that both `.address` and `._address` are set. I ran into a weird case where I expected to see one, but saw the other instead. This should make sure the address is always accessible.