### PR TITLE
Support latest DelegatedSending, adding utility functions

### DIFF
--- a/delegatedSending.js
+++ b/delegatedSending.js
@@ -67,7 +67,7 @@ module.exports.canReceive = internal.canReceive
  *      or spawn limits are being hit
  * @param {Number} as - point to send the planets with
  * @param {Number} amount - amount of planets to generate
- * @return {Array<Number>} Pseudo-random list of planets that as can send
+ * @return {Promise<Array<Number>>} Pseudo-random list of planets that as can send
  */
 module.exports.getPlanetsToSend = async function(contracts, as, amount) {
   const sponsor = await azimuth.getSponsor(contracts, as);

--- a/delegatedSending.js
+++ b/delegatedSending.js
@@ -8,6 +8,7 @@ const internal = require('./internal/delegatedSending');
 /**
  * Return the amount of invites left in the pool
  * @param {Number} pool - Pool number
+ * @param {Number} prefix - Invites from this prefix
  * @return {Promise<Number>} Number of invites remaining
  */
 module.exports.pools = internal.pools
@@ -44,6 +45,13 @@ module.exports.getPool = internal.getPool
 module.exports.invitingFromPool = internal.getPool
 
 /**
+ * Get the stars that have put invites into the pool
+ * @param {Number} pool - Pool number
+ * @return {Promise<Array<Number>>} Stars that touched the pool
+ */
+module.exports.getPoolStars = internal.getPoolStars
+
+/**
  * Returns true if receipients is eligible to receive a point, false otherwise
  * @param {String} recipient - Ethereum address
  * @return {Promise<Bool>} Whether recipient can receive a point
@@ -53,6 +61,7 @@ module.exports.canReceive = internal.canReceive
 
 /**
  * Give for (and their invite tree) access to size invites
+ * @param {Number} as - prefix to give invites as
  * @param {Number} for - point to give invites to
  * @param {Number} size - amount of invites to give
  * @return {Object} An unsigned transaction object

--- a/delegatedSending.js
+++ b/delegatedSending.js
@@ -4,6 +4,8 @@
  */
 
 const internal = require('./internal/delegatedSending');
+const azimuth = require('./azimuth');
+const ecliptic = require('./ecliptic');
 
 /**
  * Return the amount of invites left in the pool
@@ -57,6 +59,66 @@ module.exports.getPoolStars = internal.getPoolStars
  * @return {Promise<Bool>} Whether recipient can receive a point
  */
 module.exports.canReceive = internal.canReceive
+
+/**
+ * Generate a list of planets for as to send as invites
+ * NOTE that the returned list isn't guaranteed to contain exactly amount items,
+ *      it may return fewer in cases where not enough invites are available,
+ *      or spawn limits are being hit
+ * @param {Number} as - point to send the planets with
+ * @param {Number} amount - amount of planets to generate
+ * @return {Array<Number>} Pseudo-random list of planets that as can send
+ */
+module.exports.getPlanetsToSend = async function(contracts, as, amount) {
+  const sponsor = await azimuth.getSponsor(contracts, as);
+  const inviter = await internal.invitedBy(contracts, as);
+  const inviterSponsor = await azimuth.getSponsor(contracts, inviter);
+  const pool = await internal.getPool(contracts, as);
+  let stars = await internal.getPoolStars(contracts, as);
+
+  // assign priorities so that we can order them:
+  // sponsor > inviter's sponsor > least spawned > most spawned
+  stars = stars.map(async star => {
+    const available = await internal.pools(contracts, pool, star);
+    if (available === 0) return {star, available};
+    const spawned = await azimuth.getSpawnCount(contracts, star);
+
+    if (star === sponsor)
+      priority = -2;
+    else if (star === inviterSponsor)
+      priority = -1;
+    else if (priority === 0)
+      priority = spawned;
+
+    return {star: Number(star), available, priority};
+  });
+  stars = await Promise.all(stars);
+  stars = stars.filter(a => (a.available > 0));
+  stars = stars.sort((a, b) => (a.priority - b.priority));
+
+  let s = 0;
+  let planets = [];
+  while (amount > 0 && s < stars.length) {
+    let star = stars[s];
+    const spawnable = await ecliptic.getSpawnsRemaining(contracts, star.star);
+    const get = Math.min(star.available, spawnable, amount);
+    const unspawned = await azimuth.getUnspawnedChildren(contracts, star.star);
+
+    // make sure the first couple elements are randomized
+    for (let i = 0; i < get; i++) {
+      const j = Math.floor(Math.random() * unspawned.length);
+      [unspawned[i], unspawned[j]] = [unspawned[j], unspawned[i]];
+    }
+
+    // push number of planets to output list
+    for (let i = 0; i < get; i++) {
+      planets.push(unspawned[i]);
+    }
+    amount = amount - get;
+    s++;
+  }
+  return planets;
+}
 
 
 /**

--- a/delegatedSending.js
+++ b/delegatedSending.js
@@ -80,9 +80,13 @@ module.exports.getPlanetsToSend = async function(contracts, as, amount) {
   // sponsor > inviter's sponsor > least spawned > most spawned
   stars = stars.map(async star => {
     const available = await internal.pools(contracts, pool, star);
-    if (available === 0) return {star, available};
-    const spawned = await azimuth.getSpawnCount(contracts, star);
+    const capable = azimuth.isSpawnProxy(
+      contracts, star, contracts.delegatedSending.address
+    );
+    if (available === 0 || !(await capable))
+      return {star, available};
 
+    const spawned = await azimuth.getSpawnCount(contracts, star);
     if (star === sponsor)
       priority = -2;
     else if (star === inviterSponsor)

--- a/delegatedSending.js
+++ b/delegatedSending.js
@@ -61,6 +61,19 @@ module.exports.getPoolStars = internal.getPoolStars
 module.exports.canReceive = internal.canReceive
 
 /**
+ * Returns the total amount of invites (across all stars) available to point
+ * @param {Number} point - The point whose invites to count
+ * @return {Promise<Number>} Total amount of invites
+ */
+module.exports.getTotalInvites = async function(contracts, point) {
+  const pool = await internal.getPool(contracts, as);
+  const stars = await internal.getPoolStars(contracts, pool);
+  let counts = stars.map(star => internal.pools(contracts, pool, star));
+  counts = await Promise.all(counts);
+  return counts.reduce((total, count) => (total + count), 0);
+}
+
+/**
  * Generate a list of planets for as to send as invites
  * NOTE that the returned list isn't guaranteed to contain exactly amount items,
  *      it may return fewer in cases where not enough invites are available,

--- a/ecliptic.js
+++ b/ecliptic.js
@@ -79,10 +79,10 @@ module.exports.canEscapeTo = internal.canEscapeTo;
  * @return {Promise<Number>} The amount of children still spawnable from point.
  */
 module.exports.getSpawnsRemaining = async function(contracts, point) {
-  const count = azimuth.getSpawnCount(contracts, point);
   const now = Math.floor(new Date().getTime() / 1000);
-  const limit = internal.getSpawnLimit(contracts, point, now);
-  return ((await limit) - (await count));
+  const count = await azimuth.getSpawnCount(contracts, point);
+  const limit = await internal.getSpawnLimit(contracts, point, now);
+  return limit - count;
 }
 
 

--- a/ecliptic.js
+++ b/ecliptic.js
@@ -4,6 +4,7 @@
  */
 
 const internal = require('./internal/ecliptic');
+const azimuth = require('./azimuth');
 
 /**
  * Get ecliptic contract owner.
@@ -70,6 +71,20 @@ module.exports.getSpawnLimit = internal.getSpawnLimit;
  * @return {Promise<Bool>} True if point can escape, false otherwise.
  */
 module.exports.canEscapeTo = internal.canEscapeTo;
+
+/**
+ * Get the amount of children point can still spawn before hitting the limit.
+ * @param {Object} contracts - An Urbit contracts object.
+ * @param {Number} point - Point number.
+ * @return {Promise<Number>} The amount of children still spawnable from point.
+ */
+module.exports.getSpawnsRemaining = async function(contracts, point) {
+  const count = azimuth.getSpawnCount(contracts, point);
+  const now = Math.floor(new Date().getTime() / 1000);
+  const limit = internal.getSpawnLimit(contracts, point, now);
+  return ((await limit) - (await count));
+}
+
 
 /**
  * Safely transfer a point between addresses (call recipient if it's a contract).

--- a/internal/delegatedSending.js
+++ b/internal/delegatedSending.js
@@ -1,8 +1,6 @@
 
-//TODO ordering
-
-module.exports.pools = (contracts, point) => {
-  return contracts.delegatedSending.methods.pools(point).call();
+module.exports.pools = (contracts, pool, prefix) => {
+  return contracts.delegatedSending.methods.pools(pool, prefix).call();
 }
 
 module.exports.getInvited = (contracts, point) => {
@@ -19,6 +17,10 @@ module.exports.canSend = (contracts, as, point) => {
 
 module.exports.getPool = (contracts, point) => {
   return contracts.delegatedSending.methods.getPool(point).call();
+}
+
+module.exports.getPoolStars = (contracts, pool) => {
+  return contracts.delegatedSending.methods.getPoolStars(pool).call();
 }
 
 module.exports.canReceive = (contracts, recipient) => {
@@ -46,9 +48,9 @@ const tx = (to, data, value) => ({
   value: value || 0x0
 });
 
-module.exports.setPoolSize = (contracts, _for, _size) => {
+module.exports.setPoolSize = (contracts, _as, _for, _size) => {
   let addr = contracts.delegatedSending._address;
-  let data = contracts.delegatedSending.methods.setPoolSize(_for, _size);
+  let data = contracts.delegatedSending.methods.setPoolSize(_as, _for, _size);
   let abi  = data.encodeABI();
   return tx(addr, abi, 0);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azimuth-js",
-  "version": "0.12.0",
+  "version": "0.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -239,7 +239,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
@@ -312,9 +312,9 @@
       "dev": true
     },
     "azimuth-solidity": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/azimuth-solidity/-/azimuth-solidity-1.1.0.tgz",
-      "integrity": "sha512-YhVWKql1ZZ9Zae96nYA7QLwQlTzGspkNOErq170sl/UJwncQbvAyibSv+heMaS18n4soPDiRSpa1vHFoGoIX1A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/azimuth-solidity/-/azimuth-solidity-1.2.0.tgz",
+      "integrity": "sha512-5k50PJtJAXqZFFb0BWH6CxYGfodLNnG9VVJtjAnTxrLl8tO4qQSYWSb1nf39Q0MLT4e+rrUf5JIubZXKckmA3g==",
       "requires": {
         "babel-polyfill": "^6.26.0",
         "babel-register": "^6.26.0",
@@ -531,7 +531,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
@@ -598,7 +598,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -634,7 +634,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -841,7 +841,7 @@
     },
     "content-disposition": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
       "dev": true
     },
@@ -872,9 +872,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -904,7 +904,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -916,7 +916,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -1069,13 +1069,13 @@
       "dependencies": {
         "file-type": {
           "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
           "dev": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "requires": {
@@ -1146,7 +1146,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -1440,7 +1440,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -1516,7 +1516,7 @@
     },
     "fs-extra": {
       "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+      "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -1965,7 +1965,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -2163,7 +2163,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -2451,7 +2451,7 @@
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -2514,7 +2514,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -2577,7 +2577,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -2664,12 +2664,12 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -2711,7 +2711,7 @@
         },
         "commander": {
           "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
@@ -4036,7 +4036,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -4116,7 +4116,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -4185,7 +4185,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
@@ -4268,7 +4268,7 @@
     },
     "query-string": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "dev": true,
       "requires": {
@@ -4341,7 +4341,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -4481,7 +4481,7 @@
     },
     "scrypt.js": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
       "integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
       "dev": true,
       "requires": {
@@ -4524,7 +4524,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
@@ -4611,7 +4611,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -4629,7 +4629,7 @@
       "dependencies": {
         "nan": {
           "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
           "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
           "dev": true
         }
@@ -4768,7 +4768,7 @@
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
         "code-point-at": "^1.0.0",
@@ -4800,7 +4800,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
@@ -4809,7 +4809,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -4880,7 +4880,7 @@
     },
     "tar": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
@@ -4919,7 +4919,7 @@
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
           "dev": true
         }
@@ -4945,7 +4945,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -5092,7 +5092,7 @@
     },
     "underscore": {
       "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
       "dev": true
     },
@@ -5140,7 +5140,7 @@
     },
     "utf8": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
       "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
       "dev": true
     },
@@ -5355,7 +5355,7 @@
         },
         "uuid": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
           "dev": true
         }
@@ -5518,7 +5518,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -5602,7 +5602,7 @@
     },
     "yargs": {
       "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
       "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
       "requires": {
         "cliui": "^3.2.0",
@@ -5623,7 +5623,7 @@
     },
     "yargs-parser": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+      "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
       "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
       "requires": {
         "camelcase": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -239,7 +239,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
@@ -531,7 +531,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
@@ -598,7 +598,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -634,7 +634,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -841,7 +841,7 @@
     },
     "content-disposition": {
       "version": "0.5.2",
-      "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
       "dev": true
     },
@@ -904,7 +904,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -916,7 +916,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -1069,13 +1069,13 @@
       "dependencies": {
         "file-type": {
           "version": "3.9.0",
-          "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
           "dev": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "requires": {
@@ -1146,7 +1146,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -1440,7 +1440,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -1516,7 +1516,7 @@
     },
     "fs-extra": {
       "version": "0.30.0",
-      "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -1965,7 +1965,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -2163,7 +2163,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -2451,7 +2451,7 @@
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -2514,7 +2514,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -2577,7 +2577,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -2664,12 +2664,12 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -2711,7 +2711,7 @@
         },
         "commander": {
           "version": "2.15.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
@@ -4036,7 +4036,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -4116,7 +4116,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -4185,7 +4185,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
@@ -4268,7 +4268,7 @@
     },
     "query-string": {
       "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "dev": true,
       "requires": {
@@ -4341,7 +4341,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -4481,7 +4481,7 @@
     },
     "scrypt.js": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
       "integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
       "dev": true,
       "requires": {
@@ -4524,7 +4524,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {
@@ -4611,7 +4611,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -4629,7 +4629,7 @@
       "dependencies": {
         "nan": {
           "version": "2.10.0",
-          "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
           "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
           "dev": true
         }
@@ -4768,7 +4768,7 @@
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
         "code-point-at": "^1.0.0",
@@ -4800,7 +4800,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
@@ -4809,7 +4809,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -4880,7 +4880,7 @@
     },
     "tar": {
       "version": "2.2.1",
-      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
@@ -4919,7 +4919,7 @@
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
           "dev": true
         }
@@ -4945,7 +4945,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -5092,7 +5092,7 @@
     },
     "underscore": {
       "version": "1.8.3",
-      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
       "dev": true
     },
@@ -5140,7 +5140,7 @@
     },
     "utf8": {
       "version": "2.1.1",
-      "resolved": "http://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
       "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
       "dev": true
     },
@@ -5355,7 +5355,7 @@
         },
         "uuid": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
           "dev": true
         }
@@ -5518,7 +5518,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -5602,7 +5602,7 @@
     },
     "yargs": {
       "version": "4.8.1",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
       "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
       "requires": {
         "cliui": "^3.2.0",
@@ -5623,7 +5623,7 @@
     },
     "yargs-parser": {
       "version": "2.4.1",
-      "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
       "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
       "requires": {
         "camelcase": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "web3": "1.0.0-beta.33"
   },
   "dependencies": {
-    "azimuth-solidity": "1.1.0",
+    "azimuth-solidity": "1.2.0",
     "ethereumjs-util": "^5.2.0"
   },
   "peerDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -541,7 +541,14 @@ function main() {
       let invited = await delsend.getInvited(contracts, planet1c);
       assert.equal(invited.length, 1);
       assert.equal(invited[0], planet1d);
-    })
+    });
+
+    it('generates planets to send', async function() {
+      let shortList = await delsend.getPlanetsToSend(contracts, planet1c, 3);
+      let longList = await delsend.getPlanetsToSend(contracts, planet1c, 15);
+      assert.equal(shortList.length, 3);
+      assert.equal(longList.length, 8);
+    });
   });
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -514,12 +514,12 @@ function main() {
     });
 
     it('generates usable transaction', async function() {
-      assert.equal(await delsend.pools(contracts, planet1c), 0);
+      assert.equal(await delsend.pools(contracts, planet1c, star1), 0);
 
-      let tx = delsend.setPoolSize(contracts, planet1c, 9);
+      let tx = delsend.setPoolSize(contracts, star1, planet1c, 9);
       await sendTransaction(web3, tx, pk0);
 
-      assert.equal(await delsend.pools(contracts, planet1c), 9);
+      assert.equal(await delsend.pools(contracts, planet1c, star1), 9);
     });
 
     it('checks invite send ability', async function() {
@@ -535,7 +535,7 @@ function main() {
       await sendTransaction(web3, tx, pk0);
 
       assert.isTrue(await azimuth.isTransferProxy(contracts, planet1d, ac2));
-      assert.equal(await delsend.pools(contracts, planet1c), 8);
+      assert.equal(await delsend.pools(contracts, planet1c, star1), 8);
       assert.equal(await delsend.invitedBy(contracts, planet1d), planet1c);
       assert.equal(await delsend.getPool(contracts, planet1d), planet1c);
       let invited = await delsend.getInvited(contracts, planet1c);


### PR DESCRIPTION
This updates the `delegatedSending` interface to fully support the latest version of that contract. Additionally, it adds a helper function, `getPlanetsToSend`, to get, well, planets to send as invites.

The way to-send planets are obtained in that function may seem like a little much, but it's not that bad. Here's the tldr:
1. get stars we have invites for
2. sort them by priority*
then, until we've found the requested number of planets:
3. go down the sorted list of stars, get the unspawned planets
4. shuffle the list of planets, and pull out as many as we can/need
5. goto 3 if we don't have enough planets yet

\* by priority here, we mean to say how preferable it is to use invites received from this star. For this "default" case, we assume network cohesion is important. So, we prefer invites received from our sponsor, then invites from our inviter's sponsor, then whichever star has the most planets available.  
Of course, sponsorship *shouldn't* matter on most networks, but I feel it's better to err on the side of trying to match it more closely to social graphs, than to just randomize.

The sorting and shuffling isn't strictly required, but this seems like the most sane default to offer.

#22 briefly bit me while implementing this. I wonder if there's an easy way to wrap all internal calls in a function that `Number()`ifies any strings where necessary...