### PR TITLE
Add function for getting activation block for point

### DIFF
--- a/azimuth.js
+++ b/azimuth.js
@@ -390,31 +390,22 @@ async function getUnspawnedChildren(contracts, point) {
  * been activated yet.
  * @param {Object} contracts - An Urbit contracts object.
  * @param {Number} point - Point number.
- * @param {Number} maxBlock - Block to start backwards search from. You
- *                            generally want to pass in web3.eth.getBlockNumber.
- * @param {Number} minBlock - (optional) Block to end backwards search at.
+ * @param {Number} minBlock - (optional) Block to start search at. (Default 0.)
+ * @param {Number} maxBlock - (optional) Block to end search at. (Default latest.)
  * @return {Promise<Number>} - Block of activation.
  */
-async function getActivationBlock(contracts, point, maxBlock, minBlock) {
+async function getActivationBlock(contracts, point, minBlock, maxBlock) {
   minBlock = minBlock || 0;
-  let block = maxBlock;
-  let res = null;
-  while (block > minBlock && res === null) {
-    const lower = block - 45000; // approximately a week
-    const logs = await contracts.azimuth.getPastEvents('Activated', {
-      fromBlock: lower,
-      toBlock: block,
-      filter: { point: [point] },
-    });
-    if (logs.length > 0) {
-      res = logs[0];
-    }
-    block = lower;
-  }
-  if (res === null) {
+  maxBlock = maxBlock || 'latest';
+  const logs = await contracts.azimuth.getPastEvents('Activated', {
+    fromBlock: minBlock,
+    toBlock: maxBlock,
+    filter: { point: [point] },
+  });
+  if (logs.length === 0) {
     return 0;
   } else {
-    return res.blockNumber;
+    return logs[0].blockNumber;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const azimuth = require('./azimuth');
 const delegatedSending = require('./delegatedSending');
 const txn = require('./txn');
 const utils = require('./utils');
+const chainDetails = require('./resources/chainDetails.json');
 
 const initContracts = contracts.initContracts;
 const initContractsPartial = contracts.initContractsPartial;
@@ -34,5 +35,6 @@ module.exports = {
   utils,
   initContracts,
   initContractsPartial,
-  getKeyPair
+  getKeyPair,
+  chainDetails
 }

--- a/resources/chainDetails.json
+++ b/resources/chainDetails.json
@@ -1,0 +1,20 @@
+{
+  "mainnet": {
+    "azimuth": {
+      "address": "0x223c067F8CF28ae173EE5CafEa60cA44C335fecB",
+      "genesis": 6784880
+    }
+  },
+  "ropsten": {
+    "azimuth": {
+      "address": "0x308ab6a6024cf198B57e008d0Ac9Ad0219886579",
+      "genesis": 4601630
+    }
+  },
+  "local": {
+    "azimuth": {
+      "address": "0x863d9c2e5c4c133596cfac29d55255f0d0f86381",
+      "genesis": 0
+    }
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,7 @@ const check = ajs.check;
 const ecliptic = ajs.ecliptic;
 const azimuth = ajs.azimuth;
 const delsend = ajs.delegatedSending;
+const details = ajs.chainDetails;
 const txn = ajs.txn;
 
 const reasons = require('../resources/reasons.json');
@@ -101,6 +102,7 @@ function main() {
   let galaxyPlanet = 65536;
   let star1        = 256;
   let star2        = 512;
+  let star3        = 768;
   let planet1a     = 65792;
   let planet1b     = 131328;
   let planet1c     = 196864;
@@ -574,6 +576,31 @@ function main() {
 
       count = await delsend.getTotalUsableInvites(contracts, planet1c);
       assert.equal(count, 8);
+    });
+  });
+
+  describe('#eventLog', async function() {
+
+    it('can find activated ship block', async function() {
+      const latest = await web3.eth.getBlockNumber();
+      const res = await azimuth.getActivationBlock(
+        contracts,
+        star1,
+        latest,
+        details.local.azimuth.genesis
+      );
+      assert.notEqual(res, 0);
+    });
+
+    it('cannot find unactivated ship block', async function() {
+      const latest = await web3.eth.getBlockNumber();
+      const res = await azimuth.getActivationBlock(
+        contracts,
+        star3,
+        latest,
+        details.local.azimuth.genesis
+      );
+      assert.equal(res, 0);
     });
   });
 }

--- a/test/test.js
+++ b/test/test.js
@@ -586,8 +586,8 @@ function main() {
       const res = await azimuth.getActivationBlock(
         contracts,
         star1,
-        latest,
-        details.local.azimuth.genesis
+        details.local.azimuth.genesis,
+        latest
       );
       assert.notEqual(res, 0);
     });
@@ -597,8 +597,8 @@ function main() {
       const res = await azimuth.getActivationBlock(
         contracts,
         star3,
-        latest,
-        details.local.azimuth.genesis
+        details.local.azimuth.genesis,
+        latest
       );
       assert.equal(res, 0);
     });


### PR DESCRIPTION
This one feels really awkward and probably needs some work.

What I _wanted_ to implement was a simple `getActivationTime(contracts, point)`...  
but we can't get the latest block without Web3, and we can't know the Azimuth genesis block if we don't know what network we're on. These are important for defining event log search boundaries.

We fumble our way around that by:
- Adding a `maxBlock` argument so we don't need Web3,
- Adding a `minBlock` argument, and providing genesis block information to use with that in `chainDetails`.

I like the addition of `chainDetails`, we could also use it to provide an `initializeDefaultContracts(network)` function. But everything else about this feels like it's a bit meh. Happy to take suggestions for improvements.  
Perhaps if the function signature is bloated anyway, I could just add in `web3` so we can at least fetch the timestamps (which we care about, nobody cares about block numbers) automatically...