### PR TITLE
Fix incorrect name for withdraw method in linearSR

### DIFF
--- a/internal/linearSR.js
+++ b/internal/linearSR.js
@@ -29,5 +29,5 @@ module.exports.withdraw = (contracts) =>
   gen.tx(contracts.linearSR, 'withdraw')
 
 module.exports.withdrawTo = (contracts, _to) =>
-  gen.tx(contracts.linearSR, 'withdrawTo', _to)
+  gen.tx(contracts.linearSR, 'withdraw', _to)
 


### PR DESCRIPTION
As per the [azimuth source](https://github.com/urbit/azimuth/blob/edf68b8da04806dd5b95994daf14cf1e7e226829/contracts/LinearStarRelease.sol#L237) withdraw() can be called with zero or one arguments