### PR TITLE
Fix getWithdrawLimit function for CSR contract

### DIFF
--- a/conditionalSR.js
+++ b/conditionalSR.js
@@ -51,11 +51,12 @@ module.exports.verifyBalance = internal.verifyBalance;
 module.exports.getStartTime = internal.getStartTime;
 
 /**
- * Return the amount of stars a participant is allowed to withdraw from their
- * commitment at the current time.
+ * Return the amount of stars a participant is allowed to withdraw from
+ * one of their batches at the current time.
  * @param {Object} contracts - An Urbit contracts object.
  * @param {String} address - The participant/registered address for the
  * commitment.
+ * @param {Number} batch - The batch number to look up
  * @return {Promise<Number>} the withdraw limit.
  */
 module.exports.getWithdrawLimit = internal.getWithdrawLimit;
@@ -98,15 +99,17 @@ module.exports.approveCommitmentTransfer = internal.approveCommitmentTransfer;
 module.exports.transferCommitment = internal.transferCommitment;
 
 /**
- * Withdraw one star to the caller's address.
+ * Withdraw one star from a batch to the caller's address.
  * @param {Object} contracts - An Urbit contracts object.
+ * @param {Number} batch - The batch number to withdraw from
  * @return {Object} An unsigned transaction object.
  */
 module.exports.withdraw = internal.withdraw;
 
 /**
- * Withdraw one star to the specified address.
+ * Withdraw one star from a batch to the specified address.
  * @param {Object} contracts - An Urbit contracts object.
+ * @param {Number} batch - The batch number
  * @param {String} address - The address to withdraw to.
  * @return {Object} An unsigned transaction object.
  */

--- a/conditionalSR.js
+++ b/conditionalSR.js
@@ -77,10 +77,16 @@ module.exports.getApprovedTransfer = internal.getApprovedTransfer;
  * { conditions, livelines, deadlines, timestamps } arrays.
  */
 module.exports.getConditionsState = async function(contracts) {
-  let [conditions, livelines, deadlines, timestamps] =
-    await internal.getConditionsState(contracts);
-  return { conditions, livelines, deadlines, timestamps };
-}
+  let { conds, deads, lives, times } = await internal.getConditionsState(
+    contracts
+  );
+  return {
+    conditions: conds,
+    livelines: lives,
+    deadlines: deads,
+    timestamps: times
+  };
+};
 
 /**
  * Approve the transfer of a commitment to another address.

--- a/internal/conditionalSR.js
+++ b/internal/conditionalSR.js
@@ -13,8 +13,8 @@ module.exports.getBatches = (contracts, address) =>
 module.exports.verifyBalance = (contracts, address) =>
   contracts.conditionalSR.methods.verifyBalance(address).call()
 
-module.exports.getWithdrawLimit = (contracts, address) =>
-  contracts.conditionalSR.methods.withdrawLimit(address).call()
+module.exports.getWithdrawLimit = (contracts, address, _batch) =>
+  contracts.conditionalSR.methods.withdrawLimit(address, _batch).call()
 
 module.exports.getApprovedTransfer = (contracts, address) =>
   contracts.conditionalSR.methods.transfers(address).call()

--- a/internal/conditionalSR.js
+++ b/internal/conditionalSR.js
@@ -28,11 +28,11 @@ module.exports.approveCommitmentTransfer = (contracts, _to) =>
 module.exports.transferCommitment = (contracts, _from) =>
   gen.tx(contracts.conditionalSR, 'transferCommitment', _from)
 
-module.exports.withdraw = (contracts) =>
-  gen.tx(contracts.conditionalSR, 'withdraw')
+module.exports.withdraw = (contracts, _batch) =>
+  gen.tx(contracts.conditionalSR, 'withdrawToSelf', _batch)
 
-module.exports.withdrawTo = (contracts, _to) =>
-  gen.tx(contracts.conditionalSR, 'withdrawTo', _to)
+module.exports.withdrawTo = (contracts, _batch, _to) =>
+  gen.tx(contracts.conditionalSR, 'withdraw', _batch, _to)
 
 module.exports.forfeit = (contracts, _batch) =>
   gen.tx(contracts.conditionalSR, 'forfeit', _batch)


### PR DESCRIPTION
The getWithdrawlimit function in azimuth-js did not match the abi
for the solidity contracts. Fixed by adding a batch number
argument, aligning it with the solidity contracts.