### PR TITLE
Account for key configuration when getting (amount of) usable invites

### DIFF
--- a/delegatedSending.js
+++ b/delegatedSending.js
@@ -71,10 +71,11 @@ module.exports.getTotalUsableInvites = async function(contracts, point) {
   const pool = await internal.getPool(contracts, point);
   const stars = await internal.getPoolStars(contracts, pool);
   let counts = stars.map(async star => {
-    const capable = await azimuth.isSpawnProxy(
+    const capable = azimuth.isSpawnProxy(
       contracts, star, contracts.delegatedSending.address
     );
-    if (!capable) return 0;
+    const supportive = azimuth.isLive(contracts, star);
+    if (!(await capable) || !(await supportive)) return 0;
     const invites = await internal.pools(contracts, pool, star);
     const spawnable = await ecliptic.getSpawnsRemaining(contracts, star);
     return Math.min(invites, spawnable);
@@ -106,8 +107,9 @@ module.exports.getPlanetsToSend = async function(contracts, as, amount) {
     const capable = azimuth.isSpawnProxy(
       contracts, star, contracts.delegatedSending.address
     );
-    if (available === 0 || !(await capable))
-      return {star, available};
+    const supportive = azimuth.isLive(contracts, star);
+    if (available === 0 || !(await capable) || !(await supportive))
+      return {star, available: 0};
 
     const spawned = await azimuth.getSpawnCount(contracts, star);
     let priority;

--- a/test/test.js
+++ b/test/test.js
@@ -537,7 +537,6 @@ function main() {
 
       assert.equal(await delsend.pools(contracts, planet1c, star1), 9);
       assert.equal(await delsend.pools(contracts, planet1c, star2), 1);
-      assert.equal(await delsend.getTotalUsableInvites(contracts, planet1c), 10);
     });
 
     it('checks invite send ability', async function() {
@@ -554,7 +553,7 @@ function main() {
 
       assert.isTrue(await azimuth.isTransferProxy(contracts, planet1d, ac2));
       assert.equal(await delsend.pools(contracts, planet1c, star1), 8);
-      assert.equal(await delsend.getTotalUsableInvites(contracts, planet1c), 9);
+      assert.equal(await delsend.getTotalUsableInvites(contracts, planet1c), 8);
       assert.equal(await delsend.invitedBy(contracts, planet1d), planet1c);
       assert.equal(await delsend.getPool(contracts, planet1d), planet1c);
       let invited = await delsend.getInvited(contracts, planet1c);
@@ -567,14 +566,27 @@ function main() {
       let longList = await delsend.getPlanetsToSend(contracts, planet1c, 15);
       let count = await delsend.getTotalUsableInvites(contracts, planet1c);
       assert.equal(shortList.length, 3);
+      assert.equal(longList.length, 8);
+      assert.equal(count, 8);
+
+      let tx = ecliptic.configureKeys(
+        contracts, star2, someBytes32, someBytes32, 1, false
+      );
+      await sendTransaction(web3, tx, pk1);
+
+      longList = await delsend.getPlanetsToSend(contracts, planet1c, 15);
+      count = await delsend.getTotalUsableInvites(contracts, planet1c);
       assert.equal(longList.length, 9);
       assert.equal(count, 9);
 
-      let tx = ecliptic.setSpawnProxy(contracts, star2, zaddr);
+      tx = ecliptic.setSpawnProxy(contracts, star2, zaddr);
       await sendTransaction(web3, tx, pk1);
 
+      longList = await delsend.getPlanetsToSend(contracts, planet1c, 15);
       count = await delsend.getTotalUsableInvites(contracts, planet1c);
+      assert.equal(longList.length, 8);
       assert.equal(count, 8);
+
     });
   });
 


### PR DESCRIPTION
In the `delegatedSending` logic, neither `getTotalUsableInvites` nor `getPlanetsToSend` were accounting for the `hasBeenLinked` check that's done in [Delegated Sending's `canSend` check](https://github.com/urbit/azimuth/blob/edf68b8da04806dd5b95994daf14cf1e7e226829/contracts/DelegatedSending.sol#L182). Because of this, they would give you planets to send as invites, that would result in failed transactions if you tried using them.

This implements that check into the aforementioned functions, and updates & expands tests to match. 

Note that while the in-contract check is `hasBeenLinked`, we use `isLive` here instead, since "is star currently capable of networking" is a more user-friendly check than "has star even been capable of networking". (cc @vvisigoth, please confirm this as fair.)