### PR TITLE
Expose mainnet Azimuth contract address

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,26 @@ npm install azimuth-js
 
 [./docs/](./docs/api.md)
 
+## Quickstart
+
+(This example uses an [Infura](https://infura.io/) endpoint as a provider for
+web3.)
+
+```
+const ajs = require('azimuth-js')
+const Web3 = require('web3')
+
+const infura   = `https://mainnet.infura.io/v3/${MY_INFURA_ID}`
+const provider = new Web3.providers.HttpProvider(infura)
+const web3     = new Web3(provider)
+
+const contracts = await ajs.initContractsPartial(web3, ajs.azimuth.mainnet)
+
+const zod = '0x3B17d097D9dd711e4Ef8517AbBF18B2Ba64381fe'
+
+ajs.azimuth.isOwner(contracts, 0, zod).then(console.log) // true
+```
+
 ## Usage
 
 Require the library via something like:

--- a/azimuth.js
+++ b/azimuth.js
@@ -18,6 +18,14 @@ const utils = require('./utils');
 //  with Promises, rather than to prevent invalid inputs *per se*.
 
 /**
+ * The Azimuth contract's address on the Ethereum mainnet.
+ *
+ * Unlike that of the Ecliptic, Polls, etc. contracts, the Azimuth contract's
+ * address never changes.  It is also registered as 'azimuth.eth' on ENS.
+ */
+const mainnet = '0x223c067f8cf28ae173ee5cafea60ca44c335fecb'
+
+/**
  * Check if an address is the owner of a point.
  * @param {Object} contracts - An Urbit contracts object.
  * @param {Number | Object} point - Point number or point object.
@@ -562,6 +570,7 @@ const getTransferringFor = internal.getTransferringFor;
 const isOperator = internal.isOperator;
 
 module.exports = {
+  mainnet,
   owner,
   getPoint,
   getOwnedPoints,

--- a/docs/api.md
+++ b/docs/api.md
@@ -156,6 +156,7 @@ Azimuth API
 
 
 * [azimuth](#module_azimuth)
+    * [~mainnet](#module_azimuth..mainnet)
     * [~getSponsoring](#module_azimuth..getSponsoring) ⇒ <code>Promise.&lt;Array.&lt;String&gt;&gt;</code>
     * [~getSponsoringCount](#module_azimuth..getSponsoringCount) ⇒ <code>Promise.&lt;Number&gt;</code>
     * [~getEscapeRequests](#module_azimuth..getEscapeRequests) ⇒ <code>Promise.&lt;Array.&lt;Number&gt;&gt;</code>
@@ -203,6 +204,15 @@ Azimuth API
     * [~getUnspawnedChildren(contracts, point)](#module_azimuth..getUnspawnedChildren) ⇒ <code>Promise.&lt;Array.&lt;Number&gt;&gt;</code>
     * [~getActivationBlock(contracts, point, minBlock, maxBlock)](#module_azimuth..getActivationBlock) ⇒ <code>Promise.&lt;Number&gt;</code>
 
+<a name="module_azimuth..mainnet"></a>
+
+### azimuth~mainnet
+The Azimuth contract's address on the Ethereum mainnet.
+
+Unlike that of the Ecliptic, Polls, etc. contracts, the Azimuth contract's
+address never changes.  It is also registered as 'azimuth.eth' on ENS.
+
+**Kind**: inner constant of [<code>azimuth</code>](#module_azimuth)  
 <a name="module_azimuth..getSponsoring"></a>
 
 ### azimuth~getSponsoring ⇒ <code>Promise.&lt;Array.&lt;String&gt;&gt;</code>


### PR DESCRIPTION
Just exposes the Azimuth contract's mainnet address, which never changes, via `azimuth.mainnet`.

Also adds a quickstart section to the README with an example of how to get going.. uh, quickly.  Prompted by [a discussion on urbit-dev](https://groups.google.com/a/urbit.org/forum/#!topic/dev/aPp4xdrzHwE).