### PR TITLE
contracts: expose individual contract creation

### DIFF
--- a/contracts.js
+++ b/contracts.js
@@ -98,10 +98,12 @@ const newConditionalStarRelease = (web3, address) =>
 module.exports = {
   initContracts,
   initContractsPartial,
-  eclipticAbi,
-  azimuthAbi,
-  pollsAbi,
-  claimsAbi,
-  linearStarReleaseAbi,
-  delegatedSendingAbi
+  //
+  newEcliptic,
+  newAzimuth,
+  newPolls,
+  newClaims,
+  newLinearStarRelease,
+  newDelegatedSending,
+  newConditionalStarRelease
 }

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ module.exports = {
   delegatedSending,
   txn,
   utils,
+  contracts,
   initContracts,
   initContractsPartial,
   getKeyPair,


### PR DESCRIPTION
So that library users can create individual contracts when desired.

Also removes contract ABIs from contracts.js' exports because they're
not used anywhere outside of it.

Required for urbit/bridge#571, so getting a new release for this after merge would be much appreciated. Shouldn't break backwards compatibility.